### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,43 +6,43 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-ChariotEPClass			KEYWORD1
-ChariotClient			KEYWORD1
+ChariotEPClass	KEYWORD1
+ChariotClient	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin					KEYWORD2
-process					KEYWORD2
-available				KEYWORD2
-createResource			KEYWORD2
+begin	KEYWORD2
+process	KEYWORD2
+available	KEYWORD2
+createResource	KEYWORD2
 triggerResourceEvent	KEYWORD2
-serialChariotCmd		KEYWORD2
-getIdFromURI			KEYWORD2
-setPutHandler			KEYWORD2
-readTMP275				KEYWORD2
-getArduinoModel			KEYWORD2
+serialChariotCmd	KEYWORD2
+getIdFromURI	KEYWORD2
+setPutHandler	KEYWORD2
+readTMP275	KEYWORD2
+getArduinoModel	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-RSRC_EVENT_INT_PIN  	LITERAL1
-CHARIOT_STATE_PIN   	LITERAL1
-MAX_BUFLEN				LITERAL1
-TMP275_ADDRESS			LITERAL1
-FAHRENHEIT    			LITERAL1
-CELSIUS       			LITERAL1
-KELVIN        			LITERAL1
-JSON          			LITERAL1
-LT            			LITERAL1
-GT            			LITERAL1
-EQ            			LITERAL1
-ON            			LITERAL1
-OFF           			LITERAL1
-LF            			LITERAL1
-CR            			LITERAL1
+RSRC_EVENT_INT_PIN	LITERAL1
+CHARIOT_STATE_PIN	LITERAL1
+MAX_BUFLEN	LITERAL1
+TMP275_ADDRESS	LITERAL1
+FAHRENHEIT	LITERAL1
+CELSIUS	LITERAL1
+KELVIN	LITERAL1
+JSON	LITERAL1
+LT	LITERAL1
+GT	LITERAL1
+EQ	LITERAL1
+ON	LITERAL1
+OFF	LITERAL1
+LF	LITERAL1
+CR	LITERAL1
 
-#define MINUTES       			1
-#define SECONDS       			2
+#define MINUTES	1
+#define SECONDS	2


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords